### PR TITLE
widen active area for triggering of column resizing pointer

### DIFF
--- a/resources/js/mixins/ResizableColumns.js
+++ b/resources/js/mixins/ResizableColumns.js
@@ -52,10 +52,10 @@ export default {
     createResizableBar(height) {
       const div = document.createElement('div');
       div.style.top = '0';
-      div.style.right = '0';
+      div.style.right = '-6px';
       div.style.position = 'absolute';
       div.style.userSelect = 'none';
-      div.style.width = '2px';
+      div.style.width = '12px';
       div.style.cursor = 'col-resize';
       div.style.height = height + 'px';
       div.style.zIndex = '10';

--- a/resources/sass/styles.scss
+++ b/resources/sass/styles.scss
@@ -17,6 +17,7 @@ table.resizable-resource-table {
       text-overflow: ellipsis;
       white-space: nowrap;
     }
+
   }
 
   th {
@@ -30,5 +31,16 @@ table.resizable-resource-table {
       z-index: 5;
       background-color: var(--50);
     }
+    &:last-of-type {
+      &::after {
+        width: 0;
+      }
+      // >div {
+          // display: none;
+      // }
+    }
   }
+
+
 }
+// vim: set ts=2 sts=-1 sw=0 et:


### PR DESCRIPTION
tl;dr -- it's very finicky to get the pointer in the right place to engage column resizing.

solution:

```js
    createResizableBar(height) {
// ...
      div.style.right = '-6px';
      div.style.width = '12px';
// ...
      return div;
    },
```

side effect: creates an unwanted 6px padding to the right of the table.  can be countered by css, which i have only partially included in scss as i am not sure the second is necessary or desirable.

```css
table.table.resizable-resource-table > thead > tr > th:last-of-type::after {
    width: 0;
}

table.table.resizable-resource-table > thead > tr > th:last-of-type > div {
    display: none;
}
```